### PR TITLE
fix so webapp will stop when appStop task is called

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,11 @@ dependencies {
             "org.springframework:spring-webmvc:${project.'spring.version'}",
             "org.springframework.security:spring-security-config:${project.'spring-security.version'}",
             "org.slf4j:slf4j-log4j12:${project.'slf4j.version'}",
+            "org.slf4j:jul-to-slf4j:${project.'slf4j.version'}",
             "commons-io:commons-io:2.11.0",
-            "javax.servlet:jstl:1.2"
+            "javax.servlet:jstl:1.2",
+            "se.jiderhamn.classloader-leak-prevention:classloader-leak-prevention-servlet:2.7.0"
+
     providedCompile "javax.servlet:jsp-api:2.0"
     testImplementation "junit:junit:4.13.2"
 }
@@ -69,6 +72,7 @@ gretty {
         programArgs.add("-Xdebug")
         programArgs.add("-Xrunjdwp:transport=dt_socket,address=5008,server=y,suspend=n")
     }
+    programArgs.add("-Djava.util.logging.config.file=./src/main/resources/logging.properties")
     logger.info("Program arguments: " + programArgs)
 
     jvmArgs = programArgs

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -16,3 +16,6 @@ log4j.logger.PROTOCOL_MESSAGE=FINEST
 
 # Logging of OpenSAML library
 log4j.logger.org.opensaml=FINEST
+
+# Logging for ClassLoader Leak Prevention
+log4j.logger.se.jiderhamn.classloader.leak.prevention=ERROR

--- a/src/main/resources/logging.properties
+++ b/src/main/resources/logging.properties
@@ -1,0 +1,1 @@
+handlers = org.slf4j.bridge.SLF4JBridgeHandler

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -14,6 +14,16 @@
         </param-value>
     </context-param>
 
+    <context-param>
+        <param-name>ClassLoaderLeakPreventor.threadWaitMs</param-name>
+        <param-value>100</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>ClassLoaderLeakPreventor.shutdownHookWaitMs</param-name>
+        <param-value>200</param-value>
+    </context-param>
+
     <servlet>
         <servlet-name>status</servlet-name>
         <servlet-class>org.springframework.security.saml.web.StatusServlet</servlet-class>
@@ -44,6 +54,11 @@
         <filter-name>springSecurityFilterChain</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
+
+    <!--ClassLoaderLeakPreventorListener should be first (outermost) listener-->
+    <listener>
+        <listener-class>se.jiderhamn.classloader.leak.prevention.ClassLoaderLeakPreventorListener</listener-class>
+    </listener>
 
     <listener>
         <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>


### PR DESCRIPTION
This makes it so the "appStop" task will work, when appStart is used to run gretty. It is using the classloader-leak-prevention-servlet to cleanup threads that aren't stopping or whatever else is keeping the app going. Using appStop should make it easier to kill this when it used by CAS in puppeteer tests. 