### PR TITLE
Fix logging issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ gretty {
         programArgs.add("-Xdebug")
         programArgs.add("-Xrunjdwp:transport=dt_socket,address=5008,server=y,suspend=n")
     }
-    programArgs.add("-Djava.util.logging.config.file=./src/main/resources/logging.properties")
+
     logger.info("Program arguments: " + programArgs)
 
     jvmArgs = programArgs

--- a/src/main/java/org/springframework/security/saml/web/ClassLoaderLeakPreventorListener.java
+++ b/src/main/java/org/springframework/security/saml/web/ClassLoaderLeakPreventorListener.java
@@ -3,7 +3,7 @@ package org.springframework.security.saml.web;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
 /**
- * Override standard logger (route it to slf4j) so we can control logging.
+ * Extend ClassLoaderLeakPreventorListener to override standard logger (route it to slf4j) so we can control logging.
  * This might risk classloader leak but we just want threads stopped.
  */
 public class ClassLoaderLeakPreventorListener

--- a/src/main/java/org/springframework/security/saml/web/ClassLoaderLeakPreventorListener.java
+++ b/src/main/java/org/springframework/security/saml/web/ClassLoaderLeakPreventorListener.java
@@ -1,0 +1,15 @@
+package org.springframework.security.saml.web;
+
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+/**
+ * Override standard logger (route it to slf4j) so we can control logging.
+ * This might risk classloader leak but we just want threads stopped.
+ */
+public class ClassLoaderLeakPreventorListener
+        extends se.jiderhamn.classloader.leak.prevention.ClassLoaderLeakPreventorListener {
+    static {
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
+    }
+}

--- a/src/main/resources/logging.properties
+++ b/src/main/resources/logging.properties
@@ -1,1 +1,0 @@
-handlers = org.slf4j.bridge.SLF4JBridgeHandler

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -57,7 +57,7 @@
 
     <!--ClassLoaderLeakPreventorListener should be first (outermost) listener-->
     <listener>
-        <listener-class>se.jiderhamn.classloader.leak.prevention.ClassLoaderLeakPreventorListener</listener-class>
+        <listener-class>org.springframework.security.saml.web.ClassLoaderLeakPreventorListener</listener-class>
     </listener>
 
     <listener>


### PR DESCRIPTION
Trying to register SLF4JBridgeHandler via system property meant that any JUL logging before the webapp was deployed would result in a messy error being logged on startup. 